### PR TITLE
Add `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing to fbcuda
+We want to make contributing to this project as easy and transparent as
+possible.
+
+## Code of Conduct
+The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+
+## Pull Requests
+We actively welcome your pull requests.
+
+1. Fork the repo and create your branch from `master`.
+2. If you've added code that should be tested, add tests.
+3. If you've changed APIs, update the documentation.
+4. Ensure the test suite passes.
+5. Make sure your code lints.
+6. If you haven't already, complete the Contributor License Agreement ("CLA").
+
+## Contributor License Agreement ("CLA")
+In order to accept your pull request, we need you to submit a CLA. You only need
+to do this once to work on any of Facebook's open source projects.
+
+Complete your CLA here: <https://code.facebook.com/cla>
+
+## Issues
+We use GitHub issues to track public bugs. Please ensure your description is
+clear and has sufficient instructions to be able to reproduce the issue.
+
+Facebook has a [bounty program](https://www.facebook.com/whitehat/) for the safe
+disclosure of security bugs. In those cases, please go through the process
+outlined on that page and do not file a public issue.
+
+## License
+By contributing to fbcuda, you agree that your contributions will be licensed
+under the LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
Adding these two documents helps new contributors and strengthens the FB Open Source Community.

In the past Facebook didn't promote including a Code of Conduct when creating new projects, so now we can fix it. :)

**why make this change?:**
Including instructions for new contributors to open source is a courtesy that will foster a welcoming and safe open source community at Facebook. Even though this project is not currently very active, it makes sense to include this document.

It also makes sense to include the `CODE_OF_CONDUCT.md`, for similar reasons;

Facebook Open Source provides a Code of Conduct statement for all
projects to follow, to promote a welcoming and safe open source community.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will improve [the fbcuda community profile](https://github.com/facebook/fbcuda/community)
checklist and increase the visibility of our COC.

**test plan:**
Viewing it on my branch -
<img width="1001" alt="screen shot 2018-01-04 at 8 29 36 am" src="https://user-images.githubusercontent.com/1114467/34573567-772ee2e6-f129-11e7-9291-9d605bf50a55.png">
<img width="1022" alt="screen shot 2018-01-04 at 8 29 49 am" src="https://user-images.githubusercontent.com/1114467/34573568-774a1052-f129-11e7-8d02-67f6aaf009d3.png">


**issue:**
internal task t23481323
  